### PR TITLE
Fix chrome devtools crash on Performance/Audit

### DIFF
--- a/src/utils/global.css
+++ b/src/utils/global.css
@@ -34,7 +34,6 @@ body {
   );
   /* reduce flash of top/bottom borders when body initially loads with no height */
   min-height: calc(100vh + var(--mega-border-width));
-  transition: border 0.5s ease-out;
 }
 
 /* header */


### PR DESCRIPTION
For some reason, Chrome devtools doesn't like the border transition. It
causes a crash whenever you try to run a performance snapshot /
lighthouse audit.